### PR TITLE
Fixed command injection through the revertTo revision string

### DIFF
--- a/lib/vizion.js
+++ b/lib/vizion.js
@@ -45,6 +45,9 @@ vizion.revertTo = function(argv, cb) {
   var revision = (argv.revision) ? argv.revision : false;
   var _folder = (argv.folder != undefined) ? argv.folder : '.';
 
+  if (revision && !/^[A-Za-z0-9]+$/.test(revision))
+    return cb('Error vizion::revertTo() received an invalid revision: ' + revision);
+
   if (!revision)
     return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
 

--- a/lib/vizion.js
+++ b/lib/vizion.js
@@ -45,11 +45,7 @@ vizion.revertTo = function(argv, cb) {
   var revision = (argv.revision) ? argv.revision : false;
   var _folder = (argv.folder != undefined) ? argv.folder : '.';
 
-  if (!revision) {
-    return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
-  } else if (!/^[A-Fa-f0-9]+$/.test(revision)) {
-    return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
-  }
+  if (!revision || !/^[A-Fa-f0-9]+$/.test(revision)) return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
 
   identify(_folder, function(type, folder) {
     if (ALL[type])

--- a/lib/vizion.js
+++ b/lib/vizion.js
@@ -45,11 +45,11 @@ vizion.revertTo = function(argv, cb) {
   var revision = (argv.revision) ? argv.revision : false;
   var _folder = (argv.folder != undefined) ? argv.folder : '.';
 
-  if (revision && !/^[A-Za-z0-9]+$/.test(revision))
-    return cb('Error vizion::revertTo() received an invalid revision: ' + revision);
-
-  if (!revision)
+  if (!revision) {
     return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
+  } else if (!/^[A-Fa-f0-9]+$/.test(revision)) {
+    return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
+  }
 
   identify(_folder, function(type, folder) {
     if (ALL[type])

--- a/lib/vizion.js
+++ b/lib/vizion.js
@@ -45,7 +45,7 @@ vizion.revertTo = function(argv, cb) {
   var revision = (argv.revision) ? argv.revision : false;
   var _folder = (argv.folder != undefined) ? argv.folder : '.';
 
-  if (!revision || !/^[A-Fa-f0-9]+$/.test(revision)) return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
+  if (!(revision && /^[A-Fa-f0-9]+$/.test(revision))) return cb({msg: 'Cannot revert to an invalid commit revision', path: _folder});
 
   identify(_folder, function(type, folder) {
     if (ALL[type])


### PR DESCRIPTION
Mitigated the command injection vulnerability by checking the revision string against a regex, to make sure it only contains letters and digits, as I observed git commit SHA's only contain those.